### PR TITLE
removing escape parentheses with -E option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Copy and paste `emojidl.sh` contents (or following snippet) into your .bashrc or
 
 ```bash
 emojidl() {
-curl -kLss "https://emojipedia.org/search/?q=$1" | grep "on Apple" | grep " 2x" | sed -n 's/.*<img src="\([^"]*\)".*/\1/p' | xargs curl -O
+curl -kLss "https://emojipedia.org/search/?q=$1" | grep "on Apple" | grep " 2x" | sed -En 's/.*<img src="([^"]*)".*/\1/p' | xargs curl -O
 }
 ```
 

--- a/emojidl.sh
+++ b/emojidl.sh
@@ -1,3 +1,3 @@
 emojidl() {
-curl -kLss "https://emojipedia.org/search/?q=$1" | grep "on Apple" | grep " 2x" | sed -n 's/.*<img src="\([^"]*\)".*/\1/p' | xargs curl -O
+curl -kLss "https://emojipedia.org/search/?q=$1" | grep "on Apple" | grep " 2x" | sed -En 's/.*<img src="([^"]*)".*/\1/p' | xargs curl -O
 }


### PR DESCRIPTION
You don't need to use parentheses when capturing groups if you use -E